### PR TITLE
Bug 1201070 - emptied signals video unload, handle abort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -788,9 +788,9 @@ ifndef APPS
   endif
 endif
 
-b2g: node_modules
+mulet: node_modules
 	DEBUG=* ./node_modules/.bin/mozilla-download \
-	--product b2g-desktop \
+	--product mulet \
 	--branch mozilla-central \
 	$(shell pwd)
 	touch -c $@
@@ -807,11 +807,11 @@ test-integration: clean $(PROFILE_FOLDER) test-integration-test
 #
 # Remember to remove this target after bug-969215 is finished !
 .PHONY: test-integration-test
-test-integration-test: b2g node_modules
+test-integration-test: mulet node_modules
 	TEST_MANIFEST=$(TEST_MANIFEST) $(NPM) run marionette -- --buildapp="$(BUILDAPP)" --reporter="$(REPORTER)"
 
 .PHONY: jsmarionette-unit-tests
-jsmarionette-unit-tests: b2g node_modules $(PROFILE_FOLDER) tests/jsmarionette/runner/marionette-js-runner/venv
+jsmarionette-unit-tests: mulet node_modules $(PROFILE_FOLDER) tests/jsmarionette/runner/marionette-js-runner/venv
 	PROFILE_FOLDER=$(PROFILE_FOLDER) ./tests/jsmarionette/run_tests.js
 
 tests/jsmarionette/runner/marionette-js-runner/venv:
@@ -1078,7 +1078,7 @@ clean:
 
 # clean out build products and tools
 really-clean: clean
-	rm -rf b2g-* .b2g-* b2g_sdk node_modules b2g modules.tar js-marionette-env "$(NODE_MODULES_CACHEDIR)"
+	rm -rf b2g-* .b2g-* b2g_sdk node_modules mulet modules.tar js-marionette-env "$(NODE_MODULES_CACHEDIR)"
 
 .git/hooks/pre-commit: tools/pre-commit
 	test -d .git && cp tools/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit || true

--- a/apps/ftu/js/tutorial.js
+++ b/apps/ftu/js/tutorial.js
@@ -43,6 +43,7 @@
       if (isVideo) {
         // must unload video and force load before switching to new source
         mediaElement.addEventListener('error', onMediaLoadOrError);
+        mediaElement.addEventListener('abort', onMediaLoadOrError);
         if (mediaElement.src) {
           mediaElement.addEventListener('emptied', onVideoUnloaded, false);
           mediaElement.addEventListener('abort', onVideoUnloaded, false);

--- a/apps/ftu/js/tutorial.js
+++ b/apps/ftu/js/tutorial.js
@@ -24,30 +24,31 @@
         evt.target.removeEventListener('error', onMediaLoadOrError);
         if (isVideo) {
           evt.target.removeEventListener('canplay', onMediaLoadOrError);
+          evt.target.removeEventListener('abort', onMediaLoadOrError);
         } else {
           evt.target.removeEventListener('load', onMediaLoadOrError);
         }
         // Dont block progress on failure to load media
         if (evt.type === 'error') {
           console.error('Failed to load tutorial media: ' + src);
+        } else if (evt.type === 'abort') {
+          console.error('Loading of tutorial media aborted: ' + src);
         }
         resolve(evt);
       }
       function onVideoUnloaded(evt) {
         mediaElement.removeEventListener('emptied', onVideoUnloaded);
-        mediaElement.removeEventListener('abort', onVideoUnloaded);
         mediaElement.addEventListener('canplay', onMediaLoadOrError);
+        mediaElement.addEventListener('abort', onMediaLoadOrError);
+        mediaElement.addEventListener('error', onMediaLoadOrError);
         mediaElement.src = src;
         mediaElement.load();
       }
       if (isVideo) {
         // must unload video and force load before switching to new source
-        mediaElement.addEventListener('error', onMediaLoadOrError);
-        mediaElement.addEventListener('abort', onMediaLoadOrError);
         if (mediaElement.src) {
-          mediaElement.addEventListener('emptied', onVideoUnloaded, false);
-          mediaElement.addEventListener('abort', onVideoUnloaded, false);
           mediaElement.removeAttribute('src');
+          mediaElement.addEventListener('emptied', onVideoUnloaded, false);
           mediaElement.load();
         } else {
           onVideoUnloaded();

--- a/bin/gaia-test
+++ b/bin/gaia-test
@@ -123,7 +123,7 @@ configure_firefox_location() {
 
 configure_b2g_location() {
   #
-  # Configure b2g test binary
+  # Configure mulet test binary
   #
   if [ ! -z "$1" ] ; then
     B2G=`which $1`
@@ -134,11 +134,11 @@ configure_b2g_location() {
   fi
 
   if [ -z "$B2G" ] ; then
-    make b2g
-    B2G="./b2g/b2g-bin"
+    make mulet
+    B2G="./firefox/firefox-bin"
     if [ ! -x "$B2G" ] ; then
       # set the path for Mac OS X
-      B2G="./b2g/Contents/MacOS/b2g-bin"
+      B2G="./firefox/Contents/MacOS/firefox-bin"
     fi
   fi
 

--- a/bin/gaia-ui-tests
+++ b/bin/gaia-ui-tests
@@ -3,16 +3,16 @@
 export GAIATEST_ACKNOWLEDGED_RISKS=true
 export GAIATEST_SKIP_WARNING=true
 
-# Get the b2g desktop binary...
-get_b2g_bin() {
-  local folder=$(find . -d 1 -name 'b2g' | cut -f 1 -d " ")
-  # Download b2g...
+# Get the mulet binary...
+get_mulet_bin() {
+  local folder=$(find . -d 1 -name 'mulet' | cut -f 1 -d " ")
+  # Download mulet ...
   if [ -z "$folder" ];
   then
     # Everything goes to stderr...
-    make b2g 1>&2
+    make mulet 1>&2
   fi
-  find $folder -follow -name "b2g-bin" | tail -n 1
+  find $folder -follow -name "firefox-bin" | tail -n 1
 }
 
 
@@ -28,12 +28,12 @@ get_profile() {
   echo $folder
 }
 
-b2g=$(get_b2g_bin)
+mulet=$(get_mulet_bin)
 root=tests/python/gaia-ui-tests/gaiatest
 profile=$(get_profile)
 gaiatest="$root/cli.py"
 
-echo "Using b2g: $b2g"
+echo "Using mulet: $mulet"
 
 # Enter the virtual env.
 source ./tests/ci/venv.sh &&
@@ -45,7 +45,7 @@ python setup.py develop && \
 cd $OLDPWD && \
 # Run the tests.
 python $gaiatest --app=b2gdesktop \
-          --binary=$b2g \
+          --binary=$mulet \
           --profile=$profile \
           --type=b2g \
           --timeout=10000 \

--- a/tests/ci/marionette_js/install
+++ b/tests/ci/marionette_js/install
@@ -1,7 +1,7 @@
 #! /bin/bash -ve
 
-echo "Downloading b2g-desktop"
-make b2g
+echo "Downloading Mulet"
+make mulet
 
 # Install virtualenv and radicale on Travis.
 make caldav-server-install

--- a/tests/ci/marionette_js_stable_check/install
+++ b/tests/ci/marionette_js_stable_check/install
@@ -1,7 +1,7 @@
 #! /bin/bash -ve
 
-echo "Downloading b2g-desktop"
-make b2g
+echo "Downloading Mulet"
+make mulet
 
 # Install virtualenv and radicale on Travis.
 make caldav-server-install

--- a/tests/ci/unit-tests-in-b2g/before_script
+++ b/tests/ci/unit-tests-in-b2g/before_script
@@ -18,18 +18,18 @@ make node_modules
 echo "Starting test-agent-server"
 make test-agent-server &
 
-echo 'Starting B2G Desktop'
+echo 'Starting Mulet'
 
-B2G_DESKTOP_PATH="./b2g/b2g-bin"
-if [ ! -x "$B2G_DESKTOP_PATH" ] ; then
+MULET_PATH="./firefox/firefox-bin"
+if [ ! -x "$MULET_PATH" ] ; then
   # set the path for Mac OS X
-  B2G_DESKTOP_PATH="./b2g/Contents/MacOS/b2g-bin"
+  MULET_PATH="./firefox/Contents/MacOS/firefox-bin"
 fi
 
 # if we still don't have it, fail
-if [ ! -x "$B2G_DESKTOP_PATH" ] ; then
-  echo "b2g desktop path doesn't exists"
+if [ ! -x "$MULET_PATH" ] ; then
+  echo "mulet path doesn't exists"
   exit 1
 fi
-$B2G_DESKTOP_PATH -profile `pwd`/profile-debug --runapp 'Test Agent' &
+$MULET_PATH -profile `pwd`/profile-debug app://test-agent.gaiamobile.org/ &
 waiting_port 8080

--- a/tests/ci/unit-tests-in-b2g/install
+++ b/tests/ci/unit-tests-in-b2g/install
@@ -1,6 +1,6 @@
 #! /bin/bash -ve
-echo 'Downloading b2g-desktop'
-make b2g
+echo 'Downloading Mulet'
+make mulet
 
 echo 'Downloading & installing node dependencies'
 make common-install

--- a/tests/jsmarionette/runner/marionette-js-runner/host/session.js
+++ b/tests/jsmarionette/runner/marionette-js-runner/host/session.js
@@ -9,7 +9,7 @@ var util = require('util');
 
 var detectBinary = Promise.denodeify(mozrunner.detectBinary);
 
-var DEFAULT_LOCATION = fsPath.join(process.cwd(), 'b2g');
+var DEFAULT_LOCATION = fsPath.join(process.cwd(), 'firefox');
 
 function Session(host, id, options) {
   this.host = host;
@@ -85,7 +85,7 @@ function resolveBinary(options) {
   if (options.runtime) return Promise.resolve(options.runtime);
 
   var binary = options.target || DEFAULT_LOCATION;
-  return detectBinary(binary, { product: 'b2g' });
+  return detectBinary(binary, { product: 'firefox' });
 }
 
 function parseCrashInfo(info) {

--- a/tests/jsmarionette/runner/mozilla-runner/test/run.js
+++ b/tests/jsmarionette/runner/mozilla-runner/test/run.js
@@ -4,18 +4,18 @@ var assert = require('assert');
 var profile = require('mozilla-profile-builder');
 var run = require('../lib/run').run;
 
-var runtime = __dirname + '/../../../../../b2g';
+var runtime = __dirname + '/../../../../../firefox';
 
 'use strict';
 suite('run', function() {
-  test('launch b2g', function(done) {
-    var options = { product: 'b2g', profile: process.env.PROFILE_FOLDER };
+  test('launch mulet', function(done) {
+    var options = { product: 'firefox', profile: process.env.PROFILE_FOLDER };
     this.timeout(5000);
     run(runtime, options, function(err, child, bin, argv) {
       assert.ok(!err, err && err.message);
 
       // verify the binary
-      assert.ok(bin.indexOf('b2g-bin') !== 0, 'has bin');
+      assert.ok(bin.indexOf('firefox-bin') !== 0, 'has bin');
 
       // verify arguments
       assert.deepEqual(
@@ -30,9 +30,9 @@ suite('run', function() {
     });
   });
 
-  test('launch b2g with different screen', function(done) {
+  test('launch mulet with different screen', function(done) {
     var options =
-      { product: 'b2g', profile: process.env.PROFILE_FOLDER,
+      { product: 'firefox', profile: process.env.PROFILE_FOLDER,
         screen: {
           width: 1280,
           height: 800,
@@ -133,9 +133,7 @@ suite('run', function() {
     });
   });
 
-  // TODO(gaye): Should re-enable. Was using firefox before
-  // and navigating to a url in b2g seems not to work the same way.
-  suite.skip('launch b2g read dump', function() {
+  suite('launch mulet read dump', function() {
     var server;
     var port = 60033;
     var config = {
@@ -173,7 +171,7 @@ suite('run', function() {
     var url = 'http://localhost:' + port + '/dump.html';
     var expected = 'WOOT DUMP';
     test('go to url', function(done) {
-      var options = { product: 'b2g', profile: profileDir, url: url };
+      var options = { product: 'firefox', profile: profileDir, url: url };
       run(runtime, options, function(err, child) {
         if (err) return done(err);
         child.stdout.on('data', function(content) {


### PR DESCRIPTION
Moved things around a bit as it looks like 'emptied' can be relied upon to signal unloading. So we can listen for abort in onVideoUnloaded
